### PR TITLE
Update Discord Handshake Link | Update home.html

### DIFF
--- a/serles/templates/home.html
+++ b/serles/templates/home.html
@@ -157,7 +157,7 @@
                 >
                 or
                 <a
-                  href="https://discord.gg/AtqtxGckqX"
+                  href="https://discord.gg/handshake"
                   target="_blank"
                   rel="noopener noreferrer"
                   class="underline"


### PR DESCRIPTION
The current link is broken. This is a global link that will always be active: https://discord.gg/handshake